### PR TITLE
fixed cram-md5 auth, was broken due to errors with byte values

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
@@ -93,7 +93,7 @@ class SMTPConnection {
         for (int i = blank; i < str.length(); i++) {
           sb.append('*');
         }
-        logStr = str.substring(0, blank + 1) + sb;
+        logStr = str.substring(0, blank) + sb;
       } else {
         logStr = str;
       }

--- a/src/test/java/io/vertx/ext/mail/MailAuthTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailAuthTest.java
@@ -19,7 +19,7 @@ public class MailAuthTest extends SMTPTestDummy {
         "334 VXNlcm5hbWU6",
         "eHh4",
         "334 UGFzc3dvcmQ6",
-        "eHh4",
+        "eXl5",
         "250 2.1.0 Ok",
         "MAIL FROM",
         "250 2.1.0 Ok",
@@ -42,10 +42,36 @@ public class MailAuthTest extends SMTPTestDummy {
         "250 AUTH LOGIN",
         "AUTH LOGIN",
         "334 VXNlcm5hbWU6",
-        "AAAA",
+        "eHh4",
         "334 UGFzc3dvcmQ6",
-        "AAAA",
+        "eXl5",
         "435 4.7.8 Error: authentication failed: authentication failure");
+
+    testException(mailServiceLogin());
+  }
+
+  @Test
+  public void authLoginStartFailTest() {
+    smtpServer.setDialogue("220 example.com ESMTP",
+        "EHLO",
+        "250-example.com\n" +
+        "250 AUTH LOGIN",
+        "AUTH LOGIN",
+        "555 login is not possible due to some error");
+
+    testException(mailServiceLogin());
+  }
+
+  @Test
+  public void authLoginUsernameFailTest() {
+    smtpServer.setDialogue("220 example.com ESMTP",
+        "EHLO",
+        "250-example.com\n" +
+        "250 AUTH LOGIN",
+        "AUTH LOGIN",
+        "334 VXNlcm5hbWU6",
+        "eHh4",
+        "555 login is not possible due to some error");
 
     testException(mailServiceLogin());
   }
@@ -56,7 +82,7 @@ public class MailAuthTest extends SMTPTestDummy {
         "EHLO",
         "250-example.com\n" +
         "250 AUTH PLAIN",
-        "AUTH PLAIN",
+        "AUTH PLAIN AHh4eAB5eXk=",
         "250 2.1.0 Ok",
         "MAIL FROM",
         "250 2.1.0 Ok",
@@ -77,7 +103,7 @@ public class MailAuthTest extends SMTPTestDummy {
         "EHLO",
         "250-example.com\n" +
         "250 AUTH PLAIN",
-        "AUTH PLAIN",
+        "AUTH PLAIN AHh4eAB5eXk=",
         "435 4.7.8 Error: authentication failed: bad protocol / cancel");
 
     testException(mailServiceLogin());
@@ -91,7 +117,7 @@ public class MailAuthTest extends SMTPTestDummy {
         "250 AUTH CRAM-MD5",
         "AUTH CRAM-MD5",
         "334 PDEyMzQuYWJjZEBleGFtcGxlLmNvbT4=",
-        "eHh4IDBGRkZGRkZDNzI3MEZGRkZGRkM4MEZGRkZGRjg4MDEyOTVGMjMwRkZGRkZGRkYwRkZGRkZGRTgwRkZGRkZGQTAxQTBGRkZGRkZERDBGRkZGRkZDNjBGRkZGRkZENTBGRkZGRkZGQg==",
+        "eHh4IDE2ZGEzMGQ5NmEwNTY4NWQ0MmQ4YzM5ZDlkMDgxOGIx",
         "250 2.1.0 Ok",
         "MAIL FROM",
         "250 2.1.0 Ok",
@@ -107,6 +133,18 @@ public class MailAuthTest extends SMTPTestDummy {
   }
 
   @Test
+  public void authCramMD5StartFailTest() {
+    smtpServer.setDialogue("220 example.com ESMTP",
+        "EHLO",
+        "250-example.com\n" +
+        "250 AUTH CRAM-MD5",
+        "AUTH CRAM-MD5",
+        "555 login is not possible due to some error");
+
+    testException(mailServiceLogin());
+  }
+
+  @Test
   public void authCramMD5FailTest() {
     smtpServer.setDialogue("220 example.com ESMTP",
         "EHLO",
@@ -114,17 +152,8 @@ public class MailAuthTest extends SMTPTestDummy {
         "250 AUTH CRAM-MD5",
         "AUTH CRAM-MD5",
         "334 PDEyMzQuYWJjZEBleGFtcGxlLmNvbT4=",
-        "AAAA",
-        "435 4.7.8 Error: authentication failed: bad protocol / cancel", 
-        "MAIL FROM",
-        "250 2.1.0 Ok",
-        "RCPT TO",
-        "250 2.1.5 Ok",
-        "DATA",
-        "354 End data with <CR><LF>.<CR><LF>",
-        "250 2.0.0 Ok: queued as ABCD",
-        "QUIT",
-        "221 2.0.0 Bye");
+        "eHh4IDE2ZGEzMGQ5NmEwNTY4NWQ0MmQ4YzM5ZDlkMDgxOGIx",
+        "435 4.7.8 Error: authentication failed: bad protocol / cancel");
 
     testException(mailServiceLogin());
   }
@@ -139,8 +168,11 @@ public class MailAuthTest extends SMTPTestDummy {
     testException(mailServiceLogin());
   }
 
+  /**
+   * test we have Login REQUIRED but no login data in the config
+   */
   @Test
-  public void authLoginMissingTest() {
+  public void authAuthDataMissingTest() {
     smtpServer.setDialogue("220 example.com ESMTP",
         "EHLO",
         "250-example.com\n" +

--- a/src/test/java/io/vertx/ext/mail/SMTPTestBase.java
+++ b/src/test/java/io/vertx/ext/mail/SMTPTestBase.java
@@ -84,7 +84,7 @@ public class SMTPTestBase extends VertxTestBase {
    * @return
    */
   private MailConfig configLogin() {
-    return configLogin("xxx", "xxx");
+    return configLogin("xxx", "yyy");
   }
 
   /**

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPAuthenticationTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPAuthenticationTest.java
@@ -1,0 +1,49 @@
+/**
+ * 
+ */
+package io.vertx.ext.mail.impl;
+
+import static org.junit.Assert.*;
+import io.vertx.ext.mail.impl.SMTPAuthentication;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
+ *
+ */
+public class SMTPAuthenticationTest {
+
+  /**
+   * Test method for
+   * {@link io.vertx.ext.mail.impl.SMTPAuthentication#encodeHex(byte[])}.
+   */
+  @Test
+  public final void testEncodeHex() {
+    assertEquals("", SMTPAuthentication.encodeHex(new byte[] {}));
+    assertEquals("00", SMTPAuthentication.encodeHex(new byte[] { 0 }));
+    assertEquals("01", SMTPAuthentication.encodeHex(new byte[] { 1 }));
+    assertEquals("7f", SMTPAuthentication.encodeHex(new byte[] { 127 }));
+    assertEquals("80", SMTPAuthentication.encodeHex(new byte[] { (byte) 128 }));
+    assertEquals("ff", SMTPAuthentication.encodeHex(new byte[] { (byte) 255 }));
+    assertEquals("ffffffff",
+        SMTPAuthentication.encodeHex(new byte[] { (byte) 255, (byte) 255, (byte) 255, (byte) 255 }));
+
+    byte[] bytes = new byte[256];
+    for (int i = 0; i < 256; i++) {
+      bytes[i] = (byte) i;
+    }
+    assertEquals(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+        SMTPAuthentication.encodeHex(bytes));
+  }
+
+  @Test
+  public final void testHMacMD5() {
+    assertEquals("80070713463e7749b90c2dc24911e275",
+        SMTPAuthentication.hmacMD5hex("key", "The quick brown fox jumps over the lazy dog"));
+    assertEquals("3e77dd1d6bd3df877751b303bc7430f0",
+        SMTPAuthentication.hmacMD5hex("The quick brown fox jumps over the lazy dog", "key"));
+  }
+
+}


### PR DESCRIPTION
fixed the unit test, which checked the wrong results
improved error checking for the different auth methods
added/fixed unit tests to the check for the different errors
